### PR TITLE
Use a proper temp file.

### DIFF
--- a/plot_google_map.m
+++ b/plot_google_map.m
@@ -346,8 +346,9 @@ sensor = '&sensor=false';
 url = [preamble location zoomStr sizeStr maptypeStr format markers labelsStr languageStr sensor keyStr];
 
 % Get the image
+filepath = fullfile(tempdir, filename);
 try
-    urlwrite(url,filename);
+    urlwrite(url,filepath);
 catch % error downloading map
     warning(sprintf(['Unable to download map form Google Servers.\n' ...
         'Possible reasons: no network connection, quota exceeded, or some other error.\n' ...
@@ -358,9 +359,9 @@ catch % error downloading map
     varargout{3} = [];
     return
 end
-[M Mcolor] = imread(filename);
+[M Mcolor] = imread(filepath);
 M = cast(M,'double');
-delete(filename); % delete temp file
+delete(filepath); % delete temp file
 width = size(M,2);
 height = size(M,1);
 

--- a/plot_google_map.m
+++ b/plot_google_map.m
@@ -569,5 +569,3 @@ for idx = 1:length(axes_objs)
         plot_google_map(params{:});
     end
 end
-
-    


### PR DESCRIPTION
Standalone compiled Matlab programs have a default path wherever they are installed. For most OSes, writing to the program installation directory (\Program Files for Windows; /Applications for OSX) is a privileged operation. For normal users this will fail. Most OSes provide a directory for temporary files generated by user programs, as well as an API to find it. Matlab provides the cross-platform tempdir function for this purpose. A commit in this PR allows plot_google_map to be used in standalone compiled Matlab programs.
